### PR TITLE
Fixed install

### DIFF
--- a/spdlog/buildfile
+++ b/spdlog/buildfile
@@ -59,6 +59,6 @@ else
 #
 {hxx ixx txx}{*}:
 {
-  install         = include/spdlog/
+  install         = $install.root
   install.subdirs = true
 }


### PR DESCRIPTION
This fixes the build on linux by fixing the install path of headers which was wrong due to the change to symbolic-link + keeping the directory structure.

Windows doesn't work yet,.