### PR TITLE
Fixes for linking on Windows/msvc

### DIFF
--- a/spdlog/buildfile
+++ b/spdlog/buildfile
@@ -4,7 +4,6 @@ import intf_libs += fmt%lib{fmt}
 
 lib{spdlog}: {cxx hxx}{**} $impl_libs $intf_libs
 
-cxx.poptions += -DSPDLOG_FMT_EXTERNAL
 
 if ($cxx.target.class != 'windows')
 {
@@ -26,24 +25,28 @@ if ($cxx.target.class != 'windows')
 # Build options.
 #
 cxx.poptions =+ "-I$out_root" "-I$src_root" "-I$src_base/include"
+cxx.poptions += -DSPDLOG_COMPILED_LIB
+# fmt is a package dependency
+cxx.poptions += -DSPDLOG_FMT_EXTERNAL
 
-objs{*}: cxx.poptions += -DSPDLOG_SHARED_LIB -DFMT_EXPORT -DFMT_SHARED
+objs{*}: cxx.poptions += -DSPDLOG_SHARED_LIB -Dspdlog_EXPORTS
 
-src/
+if($cxx.target.class == 'windows')
 {
-    cxx.poptions += -DSPDLOG_COMPILED_LIB
-    objs{*}: cxx.poptions += -DFMT_EXPORT -DFMT_SHARED
+  cxx.libs += Advapi32.lib
+  lib{spdlog}: cxx.export.libs += Advapi32.lib
 }
 
 # Export options.
 #
 lib{spdlog}:
 {
-  cxx.export.poptions = "-I$out_root" "-I$src_root" "-I$src_base/include"
-  cxx.export.libs = $intf_libs
+  cxx.export.poptions += "-I$out_root" "-I$src_root" "-I$src_base/include"
+  cxx.export.libs += $intf_libs
 }
 
-libs{spdlog}: cxx.export.poptions += -DSPDLOG_SHARED_LIB -DFMT_SHARED
+libs{spdlog}: cxx.export.poptions += -DSPDLOG_SHARED_LIB -DSPDLOG_FMT_EXTERNAL
+
 
 # For pre-releases use the complete version to make sure they cannot be used
 # in place of another pre-release or the final version. See the version module


### PR DESCRIPTION
This fixes the linking issues on windows/msvc (not windows/gcc).
Some important notes:

- I had to look at the common.h header see which macros should be set in which case, because the cmakelists mostly assumes usage of the fmt copy/pasted in the sources. Here we want to use the fmt from the package, so we must not set anything related to fmt itself in the spdlog package;
- it was not documented (and suppoorted) but on msvc to make the SPDLOG_API macros actually do the right thing, the spdlog_EXPORT macro had to be defined, so I set it in case of shared library being built;
- I had to make sure the user of spdlog also don't try to get fmt from the spdlog package but as it's own package;
- on Windows, one of the sinks is using a system library which is Advapi32.lib, so I added the depdency. They don't support windows officially and I think that's the main reason.

